### PR TITLE
added 4 streams. Not tests if actually working

### DIFF
--- a/hal/rtl8814a/rtl8814a_hal_init.c
+++ b/hal/rtl8814a/rtl8814a_hal_init.c
@@ -3986,8 +3986,8 @@ void init_hal_spec_8814a(_adapter *adapter)
 	hal_spec->macid_num = MACID_NUM_8814A;
 	hal_spec->sec_cam_ent_num = SEC_CAM_ENT_NUM_8814A;
 	hal_spec->sec_cap = SEC_CAP_CHK_BMC;
-	hal_spec->tx_nss_num = 1;
-	hal_spec->rx_nss_num = 1;
+	hal_spec->tx_nss_num = 4;
+	hal_spec->rx_nss_num = 4;
 	hal_spec->band_cap = BAND_CAP_8814A;
 	hal_spec->bw_cap = BW_CAP_8814A;
 


### PR DESCRIPTION
With this modification, I can see:
	1 streams: MCS 0-9
	2 streams: MCS 0-9
	3 streams: MCS 0-9
	4 streams: not supported
	5 streams: not supported
	6 streams: not supported
	7 streams: not supported
	8 streams: not supported


Still missing 1 stream it seems, strange...