### PR TITLE
fix scan timeout in driver

### DIFF
--- a/core/rtw_cmd.c
+++ b/core/rtw_cmd.c
@@ -923,7 +923,7 @@ u8 rtw_sitesurvey_cmd(_adapter  *padapter, NDIS_802_11_SSID *ssid, int ssid_num,
 	if (res == _SUCCESS) {
 
 		pmlmepriv->scan_start_time = rtw_get_current_time();
-
+#if 0 /*fariouche: looking at other wlan drivers, they do not handle timeout. It is conflicting with long scans */
 #ifdef CONFIG_SCAN_BACKOP
 		if (rtw_mi_buddy_check_mlmeinfo_state(padapter, WIFI_FW_AP_STATE)) {
 			if (is_supported_5g(padapter->registrypriv.wireless_mode)
@@ -934,7 +934,7 @@ u8 rtw_sitesurvey_cmd(_adapter  *padapter, NDIS_802_11_SSID *ssid, int ssid_num,
 		} else
 #endif /* CONFIG_SCAN_BACKOP */
 			mlme_set_scan_to_timer(pmlmepriv, SCANNING_TIMEOUT);
-
+#endif
 		rtw_led_control(padapter, LED_CTL_SITE_SURVEY);
 	} else
 		_clr_fwstate_(pmlmepriv, _FW_UNDER_SURVEY);

--- a/hal/rtl8814a/rtl8814a_phycfg.c
+++ b/hal/rtl8814a/rtl8814a_phycfg.c
@@ -1195,17 +1195,17 @@ PHY_GetTxPowerIndex_8814A(
 	PHAL_DATA_TYPE	pHalData = GET_HAL_DATA(pAdapter);
 	s8				powerDiffByRate = 0;
 	s8				txPower = 0, limit = 0;
-	u8				tx_num = MgntQuery_NssTxRate(Rate );
+	u8				ntx_idx = MgntQuery_NssTxRate(Rate );
 	BOOLEAN			bIn24G = FALSE;
 	s8				tpt_offset = 0;
 
 	/* RTW_INFO( "===>%s\n", __FUNCTION__ ); */
 	
-	txPower = (s8) PHY_GetTxPowerIndexBase( pAdapter, RFPath, Rate, tx_num, BandWidth, Channel, &bIn24G );
+	txPower = (s8) PHY_GetTxPowerIndexBase( pAdapter, RFPath, Rate, ntx_idx, BandWidth, Channel, &bIn24G );
 
 	powerDiffByRate = PHY_GetTxPowerByRate( pAdapter, (u8)(!bIn24G), RFPath, Rate );
 
-	limit = PHY_GetTxPowerLimit( pAdapter, pAdapter->registrypriv.RegPwrTblSel, (u8)(!bIn24G), pHalData->current_channel_bw, RFPath, Rate,tx_num, pHalData->current_channel);
+	limit = PHY_GetTxPowerLimit( pAdapter, pAdapter->registrypriv.RegPwrTblSel, (u8)(!bIn24G), pHalData->current_channel_bw, RFPath, Rate,ntx_idx, pHalData->current_channel);
 	tpt_offset = PHY_GetTxPowerTrackingOffset(pAdapter, RFPath, Rate);
 
 	powerDiffByRate = powerDiffByRate > limit ? limit : powerDiffByRate;
@@ -1222,6 +1222,7 @@ PHY_GetTxPowerIndex_8814A(
 	phy_TxPwrAdjInPercentage(pAdapter, (u8 *)&txPower);
 
 	if (tic) {
+		tic->ntx_idx = ntx_idx;
 		tic->base = txPower;
 		tic->by_rate = powerDiffByRate;
 		tic->limit = limit;


### PR DESCRIPTION
The timeout is too short, so it is interfering with scan, even if the scan found results.
Removed the timeout, as it seems not necessary (it is up to the userland to setup the timeout, not the driver)